### PR TITLE
Modify config/project-scratch-def.json

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -2,8 +2,8 @@
     "orgName": "apex-common-samplecode",
     "edition": "Developer",
     "settings": {
-        "orgPreferenceSettings": {
-            "s1DesktopEnabled": true
+        "lightningExperienceSettings": {
+            "enableS1DesktopEnabled": true
         }
     }
 }


### PR DESCRIPTION
On branch NewDomainStructure

Changes to be committed:
    modified:   config/project-scratch-def.json

I received the following WARNING when I created a Scratch Org using the project-scratch-def.json.

WARNING: We're deprecating OrgPreferenceSettings. We've added the settings to other metadata types in Winter '20. You can continue to use OrgPreferenceSettings until they are replaced by their corresponding settings in Spring '20. But why wait? Here's exactly what you need to update in the scratch org definition file.

Replace the orgPreferenceSettings section:
{
    "settings": {
        "orgPreferenceSettings": {
            "s1DesktopEnabled": true
        }
    }
}
With their updated settings:
{
    "settings": {
        "lightningExperienceSettings": {
            "enableS1DesktopEnabled": true
        }
    }
}